### PR TITLE
Fix MPS detection to work across different PyTorch versions

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -32,22 +32,29 @@ def list_devices():
 
         devices[f"{host}cpu"] = cpu
 
-    elif torch.mps.is_available():
-        key = f"{host}mps"
-        default_device = key
-        devices[key] = {
-            "index": 0,
-            "device": "mps",
-            "host": host,
-            "label": host + "mps",
-            "total_memory": None,
-            #"name": "MPS"
-        }
-
     else:
-        key = f"{host}cpu"
-        default_device = key
-        devices[key] = cpu
+        # Check for MPS (Apple Silicon) support
+        try:
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                key = f"{host}mps"
+                default_device = key
+                devices[key] = {
+                    "index": 0,
+                    "device": "mps",
+                    "host": host,
+                    "label": host + "mps",
+                    "total_memory": None,
+                    #"name": "MPS"
+                }
+            else:
+                key = f"{host}cpu"
+                default_device = key
+                devices[key] = cpu
+        except:
+            # Fallback to CPU if MPS check fails
+            key = f"{host}cpu"
+            default_device = key
+            devices[key] = cpu
 
     return devices, default_device
 


### PR DESCRIPTION
# MPS Detection Fix for Different PyTorch Versions

This PR fixes the Metal Performance Shaders (MPS) detection to work reliably across different PyTorch versions. The current implementation using `torch.mps.is_available()` fails on older PyTorch versions where this attribute doesn't exist.

## Changes

- Replace direct `torch.mps.is_available()` check with `torch.backends.mps.is_available()`
- Add try-except block to handle cases where MPS backend is not available
- Ensure graceful fallback to CPU when MPS check fails
- Maintain consistent device dictionary structure across all cases

## Why

The current implementation breaks on older PyTorch versions because `torch.mps` was introduced relatively recently. This change makes the MPS detection more robust by:
1. Using the more stable `torch.backends.mps` interface
2. Properly handling cases where MPS support is not available in the PyTorch installation
3. Ensuring the application continues to work by falling back to CPU

## Testing

The changes have been tested on:
- MacOS with Apple Silicon (M-series) chip
- PyTorch installation without MPS support